### PR TITLE
Fix: Preserve schema metadata in addField and bump dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["*"]
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -13,7 +13,7 @@ jobs:
       - uses: olafurpg/setup-scala@v13
       - run: sbt ci-release
         env:
-          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_SECRET: ${{ secrets.GPG_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java adoptopenjdk-11.0.27+6

--- a/build.sbt
+++ b/build.sbt
@@ -11,14 +11,14 @@ name := "savro"
 scalaVersion := scala212
 crossScalaVersions := supportedScalaVersions
 
-val AvroVersion = "1.11.1"
-val CirceVersion = "0.14.3"
+val AvroVersion = "1.11.3"
+val CirceVersion = "0.14.4"
 
 lazy val avro = Seq(
-  "org.apache.avro" % "avro"          % AvroVersion,
-  "org.apache.avro" % "avro-tools"    % AvroVersion,
-  "org.apache.avro" % "avro-compiler" % AvroVersion
-)
+  "org.apache.avro" % "avro",
+  "org.apache.avro" % "avro-tools",
+  "org.apache.avro" % "avro-compiler"
+).map(_ % AvroVersion)
 
 val circe = Seq(
   "io.circe" %% "circe-core",
@@ -28,7 +28,7 @@ val circe = Seq(
 ).map(_ % CirceVersion)
 
 libraryDependencies ++= avro ++ circe
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.15" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test
 
 /** Release related settings */
 releaseCrossBuild := true

--- a/src/main/scala/ca/dataedu/savro/AvroImplicits.scala
+++ b/src/main/scala/ca/dataedu/savro/AvroImplicits.scala
@@ -180,9 +180,16 @@ object AvroImplicits {
     ): Schema = {
       val outputSchema = Schema.createRecord(schema.getName, schema.getDoc, schema.getNamespace, false)
       val outputFieldList = {
-        for (f <- schema.getFields.asScala) yield new Field(f.name, f.schema, f.doc, f.defaultVal)
+        for (f <- schema.getFields.asScala) yield {
+          val outputField = new Field(f.name, f.schema, f.doc, f.defaultVal)
+          f.aliases.forEach(alias => outputField.addAlias(alias))
+          outputField.addAllProps(f)
+          outputField
+        }
       }.toList :+ new Field(fieldName, fieldSchema, doc.orNull, defaultValue.orNull)
       outputSchema.setFields(outputFieldList.asJava)
+      schema.getAliases.forEach(alias => outputSchema.addAlias(alias))
+      outputSchema.addAllProps(schema)
       outputSchema
     }
 


### PR DESCRIPTION
This commit addresses a bug in the `SchemaHelper.addField` method where it failed to preserve important metadata from the original schema. When adding a new field, aliases and other properties on both the top-level schema and its individual fields were being dropped.

The implementation of `addField` has been updated to explicitly copy all properties and aliases from the source schema and its fields to the newly generated schema, ensuring no metadata is lost.

Additionally, this commit includes the following dependency upgrades:

- Avro: 1.11.1 -> 1.11.3
- Circe: 0.14.3 -> 0.14.4
- ScalaTest: 3.2.15 -> 3.2.19